### PR TITLE
hotfix for width units

### DIFF
--- a/lambda/custom/apl/render-videoplayer.js
+++ b/lambda/custom/apl/render-videoplayer.js
@@ -291,18 +291,24 @@ module.exports = (playlist) => {
                                                         "type": "Text",
                                                         "id": "title",
                                                         "text": " ",
-                                                        "width": "100%",
+                                                        "width": "100vw",
                                                         "fontSize": "8vh",
-                                                        "maxLines": 2
+                                                        "maxLines": 2,
+                                                        "paddingTop": "3vh",
+                                                        "paddingLeft": "3vw",
+                                                        "paddingRight": "3vw"
                                                     },
                                                     {
                                                         "type": "Text",
                                                         "id": "subtitle",
                                                         "text": " ",
-                                                        "width": "100%",
+                                                        "width": "100vw",
                                                         "fontSize": "5vh",
                                                         "paddingTop": "3vh",
-                                                        "maxLines": 3
+                                                        "maxLines": 3,
+                                                        "paddingTop": "1vh",
+                                                        "paddingLeft": "3vw",
+                                                        "paddingRight": "3vw"
                                                     }
                                                 ]
                                             }


### PR DESCRIPTION
using % in text width breaks the rendering. Using vw achieves the wanted result to limit the text width to 100% of the view width. I also suggest adding paddings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
